### PR TITLE
Expandable News Item

### DIFF
--- a/app/lib/common/widget/NewsItem.dart
+++ b/app/lib/common/widget/NewsItem.dart
@@ -5,6 +5,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:effektio/common/store/separatedThemes.dart';
 import 'package:effektio_flutter_sdk/effektio_flutter_sdk_ffi.dart';
 import 'package:effektio_flutter_sdk/effektio_flutter_sdk.dart';
+import 'package:expandable_text/expandable_text.dart';
 
 class NewsItem extends StatefulWidget {
   const NewsItem({Key? key, required this.client, required this.news})
@@ -49,6 +50,7 @@ class _NewsItemState extends State<NewsItem> {
                   padding: const EdgeInsets.only(left: 10),
                   child: Column(
                     children: <Widget>[
+                      const Spacer(),
                       Text(
                         'Lorem Ipsum is simply dummy text of the printing and',
                         style: GoogleFonts.roboto(
@@ -67,8 +69,14 @@ class _NewsItemState extends State<NewsItem> {
                       // ignore: prefer_const_constructors
                       SizedBox(height: 10),
                       // ignore: prefer_const_constructors
-                      Text(
+                      ExpandableText(
                         widget.news.text() ?? '',
+                        maxLines: 2,
+                        expandText: '',
+                        expandOnTextTap: true,
+                        collapseOnTextTap: true,
+                        animation: true,
+                        linkColor: fgColor,
                         style: GoogleFonts.roboto(
                           color: fgColor,
                           fontSize: 14,
@@ -82,6 +90,7 @@ class _NewsItemState extends State<NewsItem> {
                           ],
                         ),
                       ),
+                      const SizedBox(height: 10),
                     ],
                   ),
                 ),

--- a/app/lib/screens/HomeScreens/ChatScreen.dart
+++ b/app/lib/screens/HomeScreens/ChatScreen.dart
@@ -115,7 +115,7 @@ class _ChatScreenState extends State<ChatScreen> {
     final index = _messages.indexWhere((element) => element.id == message.id);
     final updatedMessage = _messages[index].copyWith(previewData: previewData);
 
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       setState(() {
         _messages[index] = updatedMessage;
       });

--- a/app/lib/screens/HomeScreens/ChatScreen.dart
+++ b/app/lib/screens/HomeScreens/ChatScreen.dart
@@ -18,7 +18,6 @@ import 'package:open_file/open_file.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:themed/themed.dart';
 
-
 class ChatScreen extends StatefulWidget {
   final Conversation room;
   final String? user;
@@ -116,7 +115,7 @@ class _ChatScreenState extends State<ChatScreen> {
     final index = _messages.indexWhere((element) => element.id == message.id);
     final updatedMessage = _messages[index].copyWith(previewData: previewData);
 
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance?.addPostFrameCallback((_) {
       setState(() {
         _messages[index] = updatedMessage;
       });

--- a/app/lib/screens/HomeScreens/ChatScreen.dart
+++ b/app/lib/screens/HomeScreens/ChatScreen.dart
@@ -18,6 +18,7 @@ import 'package:open_file/open_file.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:themed/themed.dart';
 
+
 class ChatScreen extends StatefulWidget {
   final Conversation room;
   final String? user;
@@ -115,7 +116,7 @@ class _ChatScreenState extends State<ChatScreen> {
     final index = _messages.indexWhere((element) => element.id == message.id);
     final updatedMessage = _messages[index].copyWith(previewData: previewData);
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
       setState(() {
         _messages[index] = updatedMessage;
       });

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.11"
+    version: "3.1.6"
   args:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   colorize_text_avatar:
     dependency: "direct main"
     description:
@@ -162,13 +162,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.3"
+  expandable_text:
+    dependency: "direct main"
+    description:
+      name: expandable_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   ffi:
     dependency: transitive
     description:
@@ -476,7 +483,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.3"
   json_annotation:
     dependency: transitive
     description:
@@ -511,7 +518,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -553,7 +560,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   path_drawing:
     dependency: transitive
     description:
@@ -747,7 +754,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   sqflite:
     dependency: transitive
     description:
@@ -810,7 +817,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.8"
   themed:
     dependency: "direct main"
     description:
@@ -894,7 +901,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   visibility_detector:
     dependency: transitive
     description:
@@ -908,7 +915,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.2.2"
+    version: "7.5.0"
   webdriver:
     dependency: transitive
     description:
@@ -945,5 +952,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.16.0 <3.0.0"
   flutter: ">=2.10.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
     path: ../effektio_flutter_sdk
   flutter_colorpicker: ^1.0.3
   emoji_picker_flutter: ^1.1.2
+  expandable_text: ^2.3.0
 
 
 dev_dependencies:


### PR DESCRIPTION
fix #116:  News Items are expandable if more than two lines by tapping and can be collapsed by tapping again.