### PR TITLE
fix NDK version r23+

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -11,37 +11,49 @@ env:
 
 jobs:
 
-  build-android:
+  cancel-others:
     runs-on: ubuntu-latest
-    name: Build Android
-    continue-on-error: true
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
+
+  build-android:
+    runs-on: ubuntu-latest
+    name: Build Android
+    continue-on-error: true
+    steps:
       - uses: actions/checkout@v2
+
       - name: Install supported toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
-          components: rust-src
+
       - uses: Swatinem/rust-cache@v1
+
       - uses: nttld/setup-ndk@v1
         with:
           ndk-version: r23c
+
       - name: Install cargo-make
         uses: davidB/rust-cargo-make@v1
+
       - name: Rust Android Setup
         run: cargo make setup-android
+
       - uses: subosito/flutter-action@v2
         name: "Set up flutter"
         with:
           channel: 'stable'
+
       - name: Build Android FFI
         run: cargo make --profile release android-arm
+
       - name: Ensure ffi-interface is up to date
         run: git diff --exit-code  effektio_flutter_sdk/lib/effektio_flutter_sdk_ffi.dart
+
       - run: flutter build apk --target-platform android-arm64 --release
         working-directory: ./app
 
@@ -91,8 +103,17 @@ jobs:
         with:
           toolchain: nightly
 
-      - run: cargo install cargo-make
-        name: "Install cargo-make"
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r23c
+
+      - name: Install cargo-make
+        uses: davidB/rust-cargo-make@v1
+
+      - name: Rust Android Setup
+        run: cargo make setup-android
 
       - uses: subosito/flutter-action@v2
         name: "Set up flutter"

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -16,6 +16,10 @@ jobs:
     name: Build Android
     continue-on-error: true
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Install supported toolchain
         uses: actions-rs/toolchain@v1
@@ -24,10 +28,11 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - uses: nttld/setup-ndk@v1
         with:
-          ndk-version: r23
-      - run: |
-          cargo install cargo-make
-          cargo make setup-android
+          ndk-version: r23c
+      - name: Install cargo-make
+        uses: davidB/rust-cargo-make@v1
+      - name: Rust Android Setup
+        run: cargo make setup-android
       - uses: subosito/flutter-action@v2
         name: "Set up flutter"
         with:

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -24,8 +24,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - uses: nttld/setup-ndk@v1
         with:
-          # FIXME: cargo-ndk doesn't work with latest
-          ndk-version: r22
+          ndk-version: r23
       - run: |
           cargo install cargo-make
           cargo make setup-android

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+          components: rust-src
       - uses: Swatinem/rust-cache@v1
       - uses: nttld/setup-ndk@v1
         with:

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -67,9 +67,10 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+      - name: Install cargo-make
+        uses: davidB/rust-cargo-make@v1
       - uses: Swatinem/rust-cache@v1
       - run: |
-          cargo install cargo-make
           cargo make setup-ios
       - uses: subosito/flutter-action@v2
         name: "Set up flutter"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,10 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - uses: nttld/setup-ndk@v1
         with:
-          # FIXME: cargo-ndk doesn't work with latest
-          ndk-version: r22
+          ndk-version: r23c
+      - name: Install cargo-make
+        uses: davidB/rust-cargo-make@v1
       - run: |
-          cargo install cargo-make
           cargo make setup-android
       - uses: subosito/flutter-action@v2
         name: "Set up flutter"
@@ -71,9 +71,10 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+      - name: Install cargo-make
+        uses: davidB/rust-cargo-make@v1
       - uses: Swatinem/rust-cache@v1
       - run: |
-          cargo install cargo-make
           cargo make setup-ios
       - uses: subosito/flutter-action@v2
         name: "Set up flutter"

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -89,9 +89,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+      - name: Install cargo-make
+        uses: davidB/rust-cargo-make@v1
       - name: "Build FFI interface"
-        run: |
-          cargo install cargo-make
-          cargo make ffigen
+        run: cargo make ffigen
       - name: "Check file is no different"
         run: git diff --exit-code effektio_flutter_sdk/lib/effektio_flutter_sdk_ffi.dart

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -172,6 +172,7 @@ args = [
   "--target",
   "${ANDROID_BUILD_TARGET}",
   "build",
+  "-Zbuild-std",
 ]
 
 [tasks.android-build-release]
@@ -185,6 +186,7 @@ args = [
   "--target",
   "${ANDROID_BUILD_TARGET}",
   "build",
+  "-Zbuild-std",
   "--release"
 ]
 

--- a/docs/content/docs/getting-started/setup.md
+++ b/docs/content/docs/getting-started/setup.md
@@ -17,8 +17,8 @@ You'll need a recent:
  - [Rustup](https://rustup.rs/) setup for Rust
  - Android NDK / XCode setup for the target - and device or simulator set up
  - [flutter](https://docs.flutter.dev/get-started/install)
- -
-_Note_ on the Android NDK. [Because of a change with the paths, you need to have NDKv22 install](https://github.com/bbqsrc/cargo-ndk/issues/38) (v23 and above don't work at the moment).
+
+_Note_ on the Android NDK. We use `cargo-ndk` internally, which we've only tested with NDK r23. If you have troubles, try removing the NDK and installing version r23 .
 
 ## Setup
 
@@ -27,7 +27,7 @@ You need `cargo make` for managing and building the native core artefacts. Insta
 
 Then you run the init once in the root of the repository:
 
-`cargo make init`
+`cargo make setup`
 
 You also need to build the core SDK once first:
 

--- a/native/cli/src/action.rs
+++ b/native/cli/src/action.rs
@@ -25,7 +25,7 @@ pub enum Action {
 
 impl Action {
     pub async fn run(&self) -> Result<()> {
-        match &*self {
+        match self {
             Action::PostNews(news) => news.run().await?,
             Action::FetchNews(config) => config.run().await?,
             Action::Mock(config) => config.run().await?,

--- a/native/core/src/events/labels.rs
+++ b/native/core/src/events/labels.rs
@@ -3,7 +3,7 @@ use serde; // 1.0.136
 use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub struct Labels {
     msgtype: Option<String>,
     tags: Vec<String>,

--- a/native/core/src/events/todos.rs
+++ b/native/core/src/events/todos.rs
@@ -15,7 +15,7 @@ pub enum SpecialTaskListRole {
     Trash,
 }
 
-#[derive(Clone, Serialize_repr, Deserialize_repr, PartialEq, Debug)]
+#[derive(Clone, Serialize_repr, Deserialize_repr, PartialEq, Eq, Debug)]
 #[repr(u8)]
 /// Implementing Priority according to
 /// <https://www.rfc-editor.org/rfc/rfc8984.html#section-4.4.1>

--- a/native/effektio/src/api/account.rs
+++ b/native/effektio/src/api/account.rs
@@ -54,7 +54,7 @@ impl Account {
                 } else {
                     Some(new_name.as_str())
                 };
-                let display_name = l.set_display_name(name).await?;
+                l.set_display_name(name).await?;
                 Ok(true)
             })
             .await?

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,7 +1,7 @@
 
 [toolchain]
-channel = "nightly-2022-03-22"
-components = ["rustfmt", "clippy", "rls"]
+channel = "nightly"
+components = ["rustfmt", "clippy", "rls", "rust-src"]
 targets = [
     "wasm32-unknown-unknown",
     "aarch64-linux-android",


### PR DESCRIPTION
we need to include `-Zbuild-std` for NDK r23+ (which is LTS). Let's do that to unbreak CI/CD. Additional this:

- [x] upgrades the toolchain back to latest `nightly` and includes the now necessary `rust-src`-component
- [x] replaces `cargo install cargo-make` in workflows with the faster `cargo-make`-action
- [x] fixes a few clippy lints that have come up since we are on latest `nightly` again now.