### PR TITLE
Minor fixes, Exclude cupertino design

### DIFF
--- a/app/lib/common/animations/like_animation.dart
+++ b/app/lib/common/animations/like_animation.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/cupertino.dart';
+
+import 'package:flutter/material.dart';
 
 class LikeAnimation {
   static AnimationController? controller;

--- a/app/lib/common/widget/NewsSideBar.dart
+++ b/app/lib/common/widget/NewsSideBar.dart
@@ -158,19 +158,22 @@ class _NewsSideBarState extends State<NewsSideBar> {
           showBottomSheet();
         }
       }),
-      child: Column(
-        children: <Widget>[
-          SvgPicture.asset(
-            'assets/images/$iconName.svg',
-            color: color,
-            width: 35,
-            height: 35,
-          ),
-          SizedBox(
-            height: 5,
-          ),
-          Text(label, style: style),
-        ],
+      child: Padding(
+        padding: const EdgeInsets.only(right: 15),
+        child: Column(
+          children: <Widget>[
+            SvgPicture.asset(
+              'assets/images/$iconName.svg',
+              color: color,
+              width: 35,
+              height: 35,
+            ),
+            SizedBox(
+              height: 5,
+            ),
+            Text(label, style: style),
+          ],
+        ),
       ),
     );
   }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -113,13 +113,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.17.1"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.4"
   diffutil_dart:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -34,7 +34,6 @@ dependencies:
   intl: ^0.17.0       
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
   path_provider: ^2.0.8
   formz: ^0.4.1
   flutter_chat_ui: ^1.6.3


### PR DESCRIPTION
Removed cupertino_icons package and Cupertino imports as per [issue159](https://github.com/effektio/effektio/issues/159)
Also added padding around comment and share icons on the main screen for a better look.