### PR TITLE
Remove twice deallocation of string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "ffi-gen"
 version = "0.1.13"
-source = "git+https://github.com/effektio/ffi-gen#23f833c076bed9aee597516f35669113d87f1b98"
+source = "git+https://github.com/effektio/ffi-gen#df0390450e0f99a951a8f9e787a04d8413182dec"
 dependencies = [
  "anyhow",
  "genco",
@@ -1035,7 +1035,7 @@ dependencies = [
 [[package]]
 name = "ffi-gen-macro"
 version = "0.1.2"
-source = "git+https://github.com/effektio/ffi-gen#23f833c076bed9aee597516f35669113d87f1b98"
+source = "git+https://github.com/effektio/ffi-gen#df0390450e0f99a951a8f9e787a04d8413182dec"
 dependencies = [
  "ffi-gen",
  "proc-macro2",

--- a/effektio_flutter_sdk/lib/effektio_flutter_sdk_ffi.dart
+++ b/effektio_flutter_sdk/lib/effektio_flutter_sdk_ffi.dart
@@ -420,11 +420,6 @@ class FfiString {
     final parts = _api._ffiStringIntoParts(_box.borrow());
     final ffi.Pointer<ffi.Uint8> tmp2_0 = ffi.Pointer.fromAddress(parts.addr);
     final tmp1 = utf8.decode(tmp2_0.asTypedList(parts.len));
-    if (parts.capacity > 0) {
-      final ffi.Pointer<ffi.Void> tmp2_0;
-      tmp2_0 = ffi.Pointer.fromAddress(parts.addr);
-      _api.__deallocate(tmp2_0, parts.capacity * 1, 1);
-    }
     return tmp1;
   }
 


### PR DESCRIPTION
Applied https://github.com/effektio/ffi-gen/pull/9.
When it is built, the following code is removed from `effektio_flutter_sdk_ffi.dart`.
```dart
    if (parts.capacity > 0) {
      final ffi.Pointer<ffi.Void> tmp2_0;
      tmp2_0 = ffi.Pointer.fromAddress(parts.addr);
      _api.__deallocate(tmp2_0, parts.capacity * 1, 1);
    }
```
This code used to deallocate string twice and it caused error.