### PR TITLE
fixing loader path for macosx release builds

### DIFF
--- a/app/macos/Runner.xcodeproj/project.pbxproj
+++ b/app/macos/Runner.xcodeproj/project.pbxproj
@@ -572,6 +572,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
 				);
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
I think this does it.