### PR TITLE
Restructure bottom bar, clean up tasks and pins

### DIFF
--- a/app/lib/common/store/themes/AppTheme.dart
+++ b/app/lib/common/store/themes/AppTheme.dart
@@ -8,6 +8,7 @@ class AppTheme {
   static ThemeData get theme {
     return ThemeData(
       textTheme: GoogleFonts.robotoTextTheme(),
+      useMaterial3: true,
       scaffoldBackgroundColor: AppCommonTheme.backgroundColor,
       dividerTheme: const DividerThemeData(
         indent: 75,

--- a/app/lib/common/store/themes/SeperatedThemes.dart
+++ b/app/lib/common/store/themes/SeperatedThemes.dart
@@ -410,3 +410,30 @@ class ToDoTheme {
     ),
   );
 }
+
+class PinsTheme {
+  // Color Scheme.
+  static const backgroundGradientColor = ColorRef(Color(0xFF242632));
+  static const backgroundGradient2Color = ColorRef(Color(0x885C2A80));
+  static const primaryTextColor = Color.fromARGB(255, 255, 255, 255);
+
+  // Text Scheme.
+  // Background Scheme.
+  static const pinsDecoration = BoxDecoration(
+    gradient: LinearGradient(
+      begin: FractionalOffset(0.5, 0.3),
+      end: Alignment.topCenter,
+      colors: [
+        PinsTheme.backgroundGradientColor,
+        PinsTheme.backgroundGradient2Color
+      ],
+    ),
+  );
+
+  // Text Scheme.
+  static const titleTextStyle = TextStyle(
+    color: primaryTextColor,
+    fontSize: 25,
+    fontWeight: FontWeight.w700,
+  );
+}

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -24,7 +24,7 @@
     "pollsVotes":"Umfragen & Abstimmungen",
     "groupBudgeting":"CoBudget",
     "sharedDocuments":"Freigegebene Dokumente",
-    "faqs":"Häufig gestellte Fragen",
+    "pins":"Pins",
     "logOut":"Abmelden",
     "login":"Einloggen",
     "signUp":"Anmelden",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -24,7 +24,7 @@
     "pollsVotes":"Polls & Votes",
     "groupBudgeting":"Group Budgeting",
     "sharedDocuments":"Shared Documents",
-    "faqs":"FAQs",
+    "pins":"Pins",
     "logOut":"Logout",
     "login":"Login",
     "signUp":"Signup",

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:effektio/controllers/chat_list_controller.dart';
 import 'package:effektio/controllers/chat_room_controller.dart';
 import 'package:effektio/controllers/receipt_controller.dart';
 import 'package:effektio/l10n/l10n.dart';
-import 'package:effektio/screens/HomeScreens/Notification.dart';
+// import 'package:effektio/screens/HomeScreens/Notification.dart';
 import 'package:effektio/screens/HomeScreens/faq/Overview.dart';
 import 'package:effektio/screens/HomeScreens/chat/Overview.dart';
 import 'package:effektio/screens/HomeScreens/news/News.dart';
@@ -16,7 +16,7 @@ import 'package:effektio/screens/SideMenuScreens/AddToDo.dart';
 import 'package:effektio/screens/SideMenuScreens/Gallery.dart';
 import 'package:effektio/screens/SideMenuScreens/ToDo.dart';
 import 'package:effektio/screens/UserScreens/SocialProfile.dart';
-import 'package:effektio/widgets/AppCommon.dart';
+// import 'package:effektio/widgets/AppCommon.dart';
 import 'package:effektio/widgets/CrossSigning.dart';
 import 'package:effektio/widgets/MaterialIndicator.dart';
 import 'package:effektio/widgets/SideMenu.dart';
@@ -142,14 +142,7 @@ class _EffektioHomeState extends State<EffektioHome>
     if (tabIndex <= 3) {
       return null;
     }
-    List<String?> titles = <String?>[
-      null,
-      'Pins',
-      'Tasks',
-      'Chat',
-    ];
     return AppBar(
-      // title: navBarTitle(titles[tabIndex] ?? ''),
       centerTitle: true,
       primary: true,
       elevation: 1,
@@ -193,14 +186,14 @@ class _EffektioHomeState extends State<EffektioHome>
   Widget buildPinsTab() {
     return Container(
       margin: const EdgeInsets.only(top: 10),
-      child: Tab(icon: Icon(FlutterIcons.pin_ent)),
+      child: const Tab(icon: Icon(FlutterIcons.pin_ent)),
     );
   }
 
   Widget buildTasksTab() {
     return Container(
       margin: const EdgeInsets.only(top: 10),
-      child: Tab(
+      child: const Tab(
         icon: Icon(FlutterIcons.tasks_faw5s),
       ),
     );

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -103,7 +103,7 @@ class _EffektioHomeState extends State<EffektioHome>
     super.initState();
 
     client = makeClient();
-    tabController = TabController(length: 5, vsync: this);
+    tabController = TabController(length: 4, vsync: this);
     tabController.addListener(() {
       setState(() => tabIndex = tabController.index);
     });

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -33,6 +33,7 @@ import 'package:flutter_mentions/flutter_mentions.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:flutter_icons_null_safety/flutter_icons_null_safety.dart';
 import 'package:themed/themed.dart';
 
 void main() async {
@@ -143,14 +144,12 @@ class _EffektioHomeState extends State<EffektioHome>
     }
     List<String?> titles = <String?>[
       null,
-      'FAQ',
-      null,
-      null,
+      'Pins',
+      'Tasks',
       'Chat',
-      'Notifications'
     ];
     return AppBar(
-      title: navBarTitle(titles[tabIndex] ?? ''),
+      // title: navBarTitle(titles[tabIndex] ?? ''),
       centerTitle: true,
       primary: true,
       elevation: 1,
@@ -191,13 +190,18 @@ class _EffektioHomeState extends State<EffektioHome>
     );
   }
 
-  Widget buildMenuTab() {
+  Widget buildPinsTab() {
+    return Container(
+      margin: const EdgeInsets.only(top: 10),
+      child: Tab(icon: Icon(FlutterIcons.pin_ent)),
+    );
+  }
+
+  Widget buildTasksTab() {
     return Container(
       margin: const EdgeInsets.only(top: 10),
       child: Tab(
-        icon: tabIndex == 1
-            ? SvgPicture.asset('assets/images/menu_bold.svg')
-            : SvgPicture.asset('assets/images/menu_linear.svg'),
+        icon: Icon(FlutterIcons.tasks_faw5s),
       ),
     );
   }
@@ -240,7 +244,7 @@ class _EffektioHomeState extends State<EffektioHome>
 
   Widget buildHomeScreen(BuildContext context, Client client) {
     return DefaultTabController(
-      length: 5,
+      length: 4,
       key: const Key('bottom-bar'),
       child: SafeArea(
         child: Scaffold(
@@ -250,9 +254,8 @@ class _EffektioHomeState extends State<EffektioHome>
             children: [
               NewsScreen(client: client),
               FaqOverviewScreen(client: client),
-              NewsScreen(client: client),
+              const ToDoScreen(),
               ChatOverview(client: client),
-              const NotificationScreen(),
             ],
           ),
           drawer: SideDrawer(client: client),
@@ -272,10 +275,9 @@ class _EffektioHomeState extends State<EffektioHome>
             ),
             tabs: [
               buildNewsFeedTab(),
-              buildMenuTab(),
-              buildPlusTab(),
+              buildPinsTab(),
+              buildTasksTab(),
               buildChatTab(),
-              buildNotificationTab(),
             ],
           ),
         ),

--- a/app/lib/screens/HomeScreens/faq/Editor.dart
+++ b/app/lib/screens/HomeScreens/faq/Editor.dart
@@ -56,7 +56,7 @@ class _HtmlEditorExampleState extends State<HtmlEditorExample> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Create FAQ',
+      title: 'Create Pin',
       theme: ThemeData.dark(),
       darkTheme: ThemeData.dark(),
       home: GestureDetector(
@@ -105,7 +105,7 @@ class _HtmlEditorExampleState extends State<HtmlEditorExample> {
             child: HtmlEditor(
               controller: controller,
               htmlEditorOptions: const HtmlEditorOptions(
-                hint: 'Write about the FAQ',
+                hint: 'What\'s the Pin about?',
                 shouldEnsureVisible: true,
               ),
               htmlToolbarOptions: HtmlToolbarOptions(

--- a/app/lib/screens/HomeScreens/faq/Item.dart
+++ b/app/lib/screens/HomeScreens/faq/Item.dart
@@ -87,7 +87,7 @@ class _FaqItemScreenState extends State<FaqItemScreen> {
                           controller: faqController,
                           style: const m_colors.TextStyle(color: Colors.white),
                           decoration: const InputDecoration(
-                            labelText: 'Faq title',
+                            labelText: 'Pin title',
                             labelStyle: TextStyle(color: Colors.white),
                             enabledBorder: OutlineInputBorder(
                               borderSide: BorderSide(color: Colors.white),

--- a/app/lib/screens/HomeScreens/faq/Overview.dart
+++ b/app/lib/screens/HomeScreens/faq/Overview.dart
@@ -1,5 +1,5 @@
 import 'package:effektio/common/store/themes/SeperatedThemes.dart';
-import 'package:effektio/screens/HomeScreens/faq/Editor.dart';
+// import 'package:effektio/screens/HomeScreens/faq/Editor.dart';
 import 'package:effektio/widgets/FaqListItem.dart';
 import 'package:effektio_flutter_sdk/effektio_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
@@ -31,43 +31,33 @@ class FaqOverviewScreen extends StatelessWidget {
           );
         } else {
           return Scaffold(
-            appBar: AppBar(
-              backgroundColor: AppCommonTheme.backgroundColor,
-              title: const Text(
-                'Pins',
-                style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
-              ),
-              centerTitle: true,
-              actions: [
-                IconButton(
-                  icon: Container(
-                    margin: const EdgeInsets.only(bottom: 10, right: 10),
-                    child: const Icon(Icons.add, color: Colors.white),
-                  ),
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => const HtmlEditorExample(
-                          title: 'Create Pin',
-                        ),
-                      ),
-                    );
-                  },
-                )
-              ],
-            ),
             body: Container(
-              color: AppCommonTheme.backgroundColor,
-              child: ListView.builder(
-                padding: const EdgeInsets.all(8),
-                itemCount: snapshot.requireData.length,
-                itemBuilder: (BuildContext context, int index) {
-                  return FaqListItem(
-                    client: client,
-                    faq: snapshot.requireData[index],
-                  );
-                },
+              decoration: PinsTheme.pinsDecoration,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 25),
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      const Padding(
+                        padding: EdgeInsets.only(left: 12),
+                        child: Text('Pins', style: PinsTheme.titleTextStyle),
+                      ),
+                      ListView.builder(
+                        padding: const EdgeInsets.all(8),
+                        physics: const NeverScrollableScrollPhysics(),
+                        shrinkWrap: true,
+                        itemCount: snapshot.requireData.length,
+                        itemBuilder: (BuildContext context, int index) {
+                          return FaqListItem(
+                            client: client,
+                            faq: snapshot.requireData[index],
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                ),
               ),
             ),
           );

--- a/app/lib/screens/HomeScreens/faq/Overview.dart
+++ b/app/lib/screens/HomeScreens/faq/Overview.dart
@@ -34,7 +34,7 @@ class FaqOverviewScreen extends StatelessWidget {
             appBar: AppBar(
               backgroundColor: AppCommonTheme.backgroundColor,
               title: const Text(
-                'Faq',
+                'Pins',
                 style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
               ),
               centerTitle: true,
@@ -49,7 +49,7 @@ class FaqOverviewScreen extends StatelessWidget {
                       context,
                       MaterialPageRoute(
                         builder: (context) => const HtmlEditorExample(
-                          title: 'Create FAQ',
+                          title: 'Create Pin',
                         ),
                       ),
                     );

--- a/app/lib/screens/SideMenuScreens/ToDo.dart
+++ b/app/lib/screens/SideMenuScreens/ToDo.dart
@@ -2,6 +2,7 @@ import 'package:effektio/common/store/MockData.dart';
 import 'package:effektio/common/store/themes/SeperatedThemes.dart';
 import 'package:effektio/controllers/todo_controller.dart';
 import 'package:flutter/material.dart';
+import 'package:effektio/widgets/AppCommon.dart';
 import 'package:get/get.dart';
 
 class ToDoScreen extends StatefulWidget {
@@ -37,15 +38,9 @@ class _ToDoScreenState extends State<ToDoScreen> {
       floatingActionButton: FloatingActionButton(
         backgroundColor: ToDoTheme.floatingABColor,
         onPressed: () {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: const Text('Add Task-List Action not yet implemented'),
-              duration: const Duration(milliseconds: 1500),
-              behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(5.0),
-              ),
-            ),
+          showNotYetImplementedMsg(
+            context,
+            'Add Task-List Action not yet implemented',
           );
         },
         child: const Icon(Icons.add_outlined, size: 25),
@@ -97,17 +92,7 @@ class _ToDoScreenState extends State<ToDoScreen> {
       splashColor: ToDoTheme.primaryTextColor,
       onTap: () {
         todoController.updateIndex(index);
-        ScaffoldMessenger.of(context).clearSnackBars();
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Text('Task filters not yet implemented'),
-            duration: const Duration(milliseconds: 1500),
-            behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(5.0),
-            ),
-          ),
-        );
+        showNotYetImplementedMsg(context, 'Task filters not yet implemented');
       },
       child: GetBuilder<ToDoController>(
         id: 'radiobtn',

--- a/app/lib/screens/SideMenuScreens/ToDo.dart
+++ b/app/lib/screens/SideMenuScreens/ToDo.dart
@@ -2,7 +2,6 @@ import 'package:effektio/common/store/MockData.dart';
 import 'package:effektio/common/store/themes/SeperatedThemes.dart';
 import 'package:effektio/controllers/todo_controller.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 
 class ToDoScreen extends StatefulWidget {
@@ -38,7 +37,16 @@ class _ToDoScreenState extends State<ToDoScreen> {
       floatingActionButton: FloatingActionButton(
         backgroundColor: ToDoTheme.floatingABColor,
         onPressed: () {
-          Navigator.pushNamed(context, '/addTodo');
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const Text('Add Task-List Action not yet implemented'),
+              duration: const Duration(milliseconds: 1500),
+              behavior: SnackBarBehavior.floating,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(5.0),
+              ),
+            ),
+          );
         },
         child: const Icon(Icons.add_outlined, size: 25),
       ),
@@ -50,26 +58,9 @@ class _ToDoScreenState extends State<ToDoScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                Row(
-                  children: [
-                    IconButton(
-                      onPressed: () {
-                        Navigator.pop(context);
-                      },
-                      icon: const Icon(Icons.arrow_back),
-                      color: ToDoTheme.primaryTextColor,
-                    ),
-                    const Spacer(),
-                    IconButton(
-                      onPressed: () {},
-                      icon: SvgPicture.asset('assets/images/notification.svg'),
-                      color: ToDoTheme.primaryTextColor,
-                    ),
-                  ],
-                ),
                 const Padding(
-                  padding: EdgeInsets.only(left: 12, top: 10),
-                  child: Text('Todo List', style: ToDoTheme.titleTextStyle),
+                  padding: EdgeInsets.only(left: 12),
+                  child: Text('Tasks', style: ToDoTheme.titleTextStyle),
                 ),
                 const Padding(
                   padding: EdgeInsets.only(left: 12, top: 10),
@@ -106,6 +97,17 @@ class _ToDoScreenState extends State<ToDoScreen> {
       splashColor: ToDoTheme.primaryTextColor,
       onTap: () {
         todoController.updateIndex(index);
+        ScaffoldMessenger.of(context).clearSnackBars();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Task filters not yet implemented'),
+            duration: const Duration(milliseconds: 1500),
+            behavior: SnackBarBehavior.floating,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(5.0),
+            ),
+          ),
+        );
       },
       child: GetBuilder<ToDoController>(
         id: 'radiobtn',

--- a/app/lib/widgets/AppCommon.dart
+++ b/app/lib/widgets/AppCommon.dart
@@ -11,6 +11,20 @@ Widget navBarTitle(String title) {
   );
 }
 
+void showNotYetImplementedMsg(BuildContext context, String message) {
+  ScaffoldMessenger.of(context).clearSnackBars();
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Text(message),
+      duration: const Duration(milliseconds: 1500),
+      behavior: SnackBarBehavior.floating,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(5.0),
+      ),
+    ),
+  );
+}
+
 String? simplifyUserId(String name) {
   RegExp re = RegExp(r'^@(\w+([\.-]?\w+)*):\w+([\.-]?\w+)*(\.\w{2,3})+$');
   RegExpMatch? match = re.firstMatch(name);

--- a/app/lib/widgets/NewsSideBar.dart
+++ b/app/lib/widgets/NewsSideBar.dart
@@ -120,50 +120,50 @@ class _NewsSideBarState extends State<NewsSideBar> {
 
   Widget buildProfileImage(Color borderColor) {
     return GestureDetector(
-        onTap: () {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: const Text('Profile Action not yet implemented'),
-              duration: const Duration(milliseconds: 1500),
-              behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(5.0),
-              ),
+      onTap: () {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Profile Action not yet implemented'),
+            duration: const Duration(milliseconds: 1500),
+            behavior: SnackBarBehavior.floating,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(5.0),
             ),
-          );
-        },
-        child: Padding(
-          padding: const EdgeInsets.only(right: 10),
-          child: Stack(
-            clipBehavior: Clip.none,
-            alignment: Alignment.bottomCenter,
-            children: [
-              CachedNetworkImage(
-                imageUrl:
-                    'https://dragonball.guru/wp-content/uploads/2021/01/goku-dragon-ball-guru.jpg',
-                height: 45,
-                width: 45,
-                imageBuilder: (context, imageProvider) => Container(
-                  decoration: BoxDecoration(
-                    border: Border.all(color: borderColor),
-                    borderRadius: BorderRadius.circular(25),
-                    image: DecorationImage(
-                      image: imageProvider,
-                      fit: BoxFit.cover,
-                      colorFilter: const ColorFilter.mode(
-                        Colors.red,
-                        BlendMode.colorBurn,
-                      ),
+          ),
+        );
+      },
+      child: Padding(
+        padding: const EdgeInsets.only(right: 10),
+        child: Stack(
+          clipBehavior: Clip.none,
+          alignment: Alignment.bottomCenter,
+          children: [
+            CachedNetworkImage(
+              imageUrl:
+                  'https://dragonball.guru/wp-content/uploads/2021/01/goku-dragon-ball-guru.jpg',
+              height: 45,
+              width: 45,
+              imageBuilder: (context, imageProvider) => Container(
+                decoration: BoxDecoration(
+                  border: Border.all(color: borderColor),
+                  borderRadius: BorderRadius.circular(25),
+                  image: DecorationImage(
+                    image: imageProvider,
+                    fit: BoxFit.cover,
+                    colorFilter: const ColorFilter.mode(
+                      Colors.red,
+                      BlendMode.colorBurn,
                     ),
                   ),
                 ),
-                placeholder: (context, url) =>
-                    const CircularProgressIndicator(),
-                errorWidget: (context, url, error) => const Icon(Icons.error),
               ),
-            ],
-          ),
-        ));
+              placeholder: (context, url) => const CircularProgressIndicator(),
+              errorWidget: (context, url, error) => const Icon(Icons.error),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   Widget buildSideBarItem(

--- a/app/lib/widgets/NewsSideBar.dart
+++ b/app/lib/widgets/NewsSideBar.dart
@@ -119,37 +119,51 @@ class _NewsSideBarState extends State<NewsSideBar> {
   }
 
   Widget buildProfileImage(Color borderColor) {
-    return Padding(
-      padding: const EdgeInsets.only(right: 10),
-      child: Stack(
-        clipBehavior: Clip.none,
-        alignment: Alignment.bottomCenter,
-        children: [
-          CachedNetworkImage(
-            imageUrl:
-                'https://dragonball.guru/wp-content/uploads/2021/01/goku-dragon-ball-guru.jpg',
-            height: 45,
-            width: 45,
-            imageBuilder: (context, imageProvider) => Container(
-              decoration: BoxDecoration(
-                border: Border.all(color: borderColor),
-                borderRadius: BorderRadius.circular(25),
-                image: DecorationImage(
-                  image: imageProvider,
-                  fit: BoxFit.cover,
-                  colorFilter: const ColorFilter.mode(
-                    Colors.red,
-                    BlendMode.colorBurn,
-                  ),
-                ),
+    return GestureDetector(
+        onTap: () {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const Text('Profile Action not yet implemented'),
+              duration: const Duration(milliseconds: 1500),
+              behavior: SnackBarBehavior.floating,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(5.0),
               ),
             ),
-            placeholder: (context, url) => const CircularProgressIndicator(),
-            errorWidget: (context, url, error) => const Icon(Icons.error),
+          );
+        },
+        child: Padding(
+          padding: const EdgeInsets.only(right: 10),
+          child: Stack(
+            clipBehavior: Clip.none,
+            alignment: Alignment.bottomCenter,
+            children: [
+              CachedNetworkImage(
+                imageUrl:
+                    'https://dragonball.guru/wp-content/uploads/2021/01/goku-dragon-ball-guru.jpg',
+                height: 45,
+                width: 45,
+                imageBuilder: (context, imageProvider) => Container(
+                  decoration: BoxDecoration(
+                    border: Border.all(color: borderColor),
+                    borderRadius: BorderRadius.circular(25),
+                    image: DecorationImage(
+                      image: imageProvider,
+                      fit: BoxFit.cover,
+                      colorFilter: const ColorFilter.mode(
+                        Colors.red,
+                        BlendMode.colorBurn,
+                      ),
+                    ),
+                  ),
+                ),
+                placeholder: (context, url) =>
+                    const CircularProgressIndicator(),
+                errorWidget: (context, url, error) => const Icon(Icons.error),
+              ),
+            ],
           ),
-        ],
-      ),
-    );
+        ));
   }
 
   Widget buildSideBarItem(
@@ -162,6 +176,17 @@ class _NewsSideBarState extends State<NewsSideBar> {
       onTap: () {
         if (iconName == 'comment') {
           showBottomSheet();
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const Text('News Action not yet implemented'),
+              duration: const Duration(milliseconds: 1500),
+              behavior: SnackBarBehavior.floating,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(5.0),
+              ),
+            ),
+          );
         }
       },
       child: Padding(

--- a/app/lib/widgets/NewsSideBar.dart
+++ b/app/lib/widgets/NewsSideBar.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:effektio/common/store/themes/SeperatedThemes.dart';
+import 'package:effektio/widgets/AppCommon.dart';
 import 'package:effektio/widgets/CommentView.dart';
 import 'package:effektio/widgets/LikeButton.dart';
 import 'package:effektio_flutter_sdk/effektio_flutter_sdk.dart';
@@ -121,16 +122,7 @@ class _NewsSideBarState extends State<NewsSideBar> {
   Widget buildProfileImage(Color borderColor) {
     return GestureDetector(
       onTap: () {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Text('Profile Action not yet implemented'),
-            duration: const Duration(milliseconds: 1500),
-            behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(5.0),
-            ),
-          ),
-        );
+        showNotYetImplementedMsg(context, 'Profile Action not yet implemented');
       },
       child: Padding(
         padding: const EdgeInsets.only(right: 10),
@@ -177,16 +169,7 @@ class _NewsSideBarState extends State<NewsSideBar> {
         if (iconName == 'comment') {
           showBottomSheet();
         } else {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: const Text('News Action not yet implemented'),
-              duration: const Duration(milliseconds: 1500),
-              behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(5.0),
-              ),
-            ),
-          );
+          showNotYetImplementedMsg(context, 'News Action not yet implemented');
         }
       },
       child: Padding(
@@ -315,11 +298,10 @@ class _NewsSideBarState extends State<NewsSideBar> {
                             ),
                             IconButton(
                               onPressed: () {
-                                const snackBar = SnackBar(
-                                  content: Text('Send icon tapped'),
+                                showNotYetImplementedMsg(
+                                  context,
+                                  'Send not yet implemented',
                                 );
-                                ScaffoldMessenger.of(context)
-                                    .showSnackBar(snackBar);
                               },
                               icon: const Icon(Icons.send, color: Colors.pink),
                             ),

--- a/app/lib/widgets/SideMenu.dart
+++ b/app/lib/widgets/SideMenu.dart
@@ -63,7 +63,7 @@ class _SideDrawerState extends State<SideDrawer> {
               buildPollsItem(),
               buildGroupBudgetingItem(),
               buildSharedDocumentsItem(),
-              buildFaqItem(),
+              buildPinsItem(),
               const SizedBox(height: 5),
               if (!widget.client.isGuest()) buildLogoutItem(context),
             ],
@@ -285,7 +285,7 @@ class _SideDrawerState extends State<SideDrawer> {
     );
   }
 
-  Widget buildFaqItem() {
+  Widget buildPinsItem() {
     return ListTile(
       leading: SvgPicture.asset(
         'assets/images/faq.svg',
@@ -294,7 +294,7 @@ class _SideDrawerState extends State<SideDrawer> {
         color: Colors.teal[700],
       ),
       title: Text(
-        AppLocalizations.of(context)!.faqs,
+        AppLocalizations.of(context)!.pins,
         style: SideMenuAndProfileTheme.sideMenuStyle,
       ),
       onTap: () {},

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -265,6 +265,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0-alpha.6"
+  flutter_icons_null_safety:
+    dependency: "direct main"
+    description:
+      name: flutter_icons_null_safety
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   flutter_inappwebview:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -72,6 +72,7 @@ dependencies:
   cached_memory_image: ^1.3.1
   flutter_mentions: ^2.0.1
   flutter_html: ^3.0.0-alpha.5
+  flutter_icons_null_safety: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This cleans up the bottom bar (in accordance with #309) and cleans up the tasks, pins and news screens:
 - [x] tasks: remove top navigation
 - [x] tasks: unimplemented features have snackbar, refs #310
 - [x] news: unimplemented features have snackbar, refs #310
 - [x] Pins: refactor for prettier screen



Fixes #309