### PR TITLE
[Patch] allow async fetch once for client info

### DIFF
--- a/app/lib/screens/HomeScreens/news/News.dart
+++ b/app/lib/screens/HomeScreens/news/News.dart
@@ -7,8 +7,15 @@ import 'package:flutter/material.dart';
 
 class NewsScreen extends StatefulWidget {
   final Client client;
+  final String? displayName;
+  final Future<FfiBufferUint8>? displayAvatar;
 
-  const NewsScreen({Key? key, required this.client}) : super(key: key);
+  const NewsScreen({
+    Key? key,
+    required this.client,
+    this.displayName,
+    this.displayAvatar,
+  }) : super(key: key);
 
   @override
   _NewsScreenState createState() => _NewsScreenState();
@@ -72,7 +79,12 @@ class _NewsScreenState extends State<NewsScreen>
                 },
               ),
             ),
-            drawer: SideDrawer(client: widget.client),
+            drawer: SideDrawer(
+              isGuest: widget.client.isGuest(),
+              userId: widget.client.userId().toString(),
+              displayName: widget.displayName,
+              displayAvatar: widget.displayAvatar,
+            ),
             body: PageView.builder(
               itemCount: snapshot.requireData.length,
               onPageChanged: (int page) {},

--- a/app/lib/widgets/SideMenu.dart
+++ b/app/lib/widgets/SideMenu.dart
@@ -1,6 +1,5 @@
 import 'package:effektio/common/store/themes/SeperatedThemes.dart';
 import 'package:effektio/screens/UserScreens/SocialProfile.dart';
-import 'package:effektio/widgets/AppCommon.dart';
 import 'package:effektio/widgets/CrossSigning.dart';
 import 'package:effektio/widgets/CustomAvatar.dart';
 import 'package:effektio_flutter_sdk/effektio_flutter_sdk.dart'
@@ -12,36 +11,19 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 import 'package:themed/themed.dart';
 
-class SideDrawer extends StatefulWidget {
-  final Client client;
+class SideDrawer extends StatelessWidget {
+  final bool isGuest;
+  final String? displayName;
+  final String userId;
+  final Future<FfiBufferUint8>? displayAvatar;
 
-  const SideDrawer({Key? key, required this.client}) : super(key: key);
-
-  @override
-  State<SideDrawer> createState() => _SideDrawerState();
-}
-
-class _SideDrawerState extends State<SideDrawer> {
-  Future<FfiBufferUint8>? avatar;
-  String? displayName;
-
-  @override
-  void initState() {
-    super.initState();
-
-    if (!widget.client.isGuest()) {
-      widget.client.getUserProfile().then((value) {
-        if (mounted) {
-          setState(() {
-            if (value.hasAvatar()) {
-              avatar = value.getAvatar();
-            }
-            displayName = value.getDisplayName();
-          });
-        }
-      });
-    }
-  }
+  const SideDrawer({
+    Key? key,
+    required this.isGuest,
+    required this.userId,
+    this.displayName,
+    this.displayAvatar,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -54,18 +36,18 @@ class _SideDrawerState extends State<SideDrawer> {
           child: Column(
             children: [
               const SizedBox(height: 20),
-              buildHeader(),
+              buildHeader(context),
               SizedBox(height: size.height * 0.04),
-              buildTodoItem(),
-              buildGalleryItem(),
-              buildEventItem(),
-              buildSharedResourcesItem(),
-              buildPollsItem(),
-              buildGroupBudgetingItem(),
-              buildSharedDocumentsItem(),
-              buildPinsItem(),
+              buildTodoItem(context),
+              buildGalleryItem(context),
+              buildEventItem(context),
+              buildSharedResourcesItem(context),
+              buildPollsItem(context),
+              buildGroupBudgetingItem(context),
+              buildSharedDocumentsItem(context),
+              buildPinsItem(context),
               const SizedBox(height: 5),
-              if (!widget.client.isGuest()) buildLogoutItem(context),
+              if (!isGuest) buildLogoutItem(context),
             ],
           ),
         ),
@@ -73,8 +55,8 @@ class _SideDrawerState extends State<SideDrawer> {
     );
   }
 
-  Widget buildHeader() {
-    if (widget.client.isGuest()) {
+  Widget buildHeader(BuildContext context) {
+    if (isGuest) {
       return Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -114,7 +96,7 @@ class _SideDrawerState extends State<SideDrawer> {
     }
     return GestureDetector(
       onTap: () {
-        Navigator.pushNamed(context, '/profile', arguments: widget.client);
+        Navigator.pushNamed(context, '/profile');
       },
       child: Row(
         children: [
@@ -122,10 +104,10 @@ class _SideDrawerState extends State<SideDrawer> {
             margin: const EdgeInsets.all(10),
             child: CustomAvatar(
               radius: 24,
-              avatar: avatar,
+              avatar: displayAvatar,
               displayName: displayName,
               isGroup: false,
-              stringName: simplifyUserId(widget.client.userId().toString())!,
+              stringName: displayName!,
             ),
           ),
           const SizedBox(width: 10),
@@ -157,12 +139,12 @@ class _SideDrawerState extends State<SideDrawer> {
 
   Widget buildUserId() {
     return Text(
-      widget.client.userId().toString(),
+      userId,
       style: SideMenuAndProfileTheme.sideMenuProfileStyle + const FontSize(14),
     );
   }
 
-  Widget buildTodoItem() {
+  Widget buildTodoItem(BuildContext context) {
     return ListTile(
       leading: SvgPicture.asset(
         'assets/images/task.svg',
@@ -180,7 +162,7 @@ class _SideDrawerState extends State<SideDrawer> {
     );
   }
 
-  Widget buildGalleryItem() {
+  Widget buildGalleryItem(BuildContext context) {
     return ListTile(
       leading: SvgPicture.asset(
         'assets/images/gallery.svg',
@@ -198,7 +180,7 @@ class _SideDrawerState extends State<SideDrawer> {
     );
   }
 
-  Widget buildEventItem() {
+  Widget buildEventItem(BuildContext context) {
     return ListTile(
       leading: SvgPicture.asset(
         'assets/images/event.svg',
@@ -214,7 +196,7 @@ class _SideDrawerState extends State<SideDrawer> {
     );
   }
 
-  Widget buildSharedResourcesItem() {
+  Widget buildSharedResourcesItem(BuildContext context) {
     return ListTile(
       leading: SvgPicture.asset(
         'assets/images/shared_resources.svg',
@@ -230,7 +212,7 @@ class _SideDrawerState extends State<SideDrawer> {
     );
   }
 
-  Widget buildPollsItem() {
+  Widget buildPollsItem(BuildContext context) {
     return ListTile(
       leading: SvgPicture.asset(
         'assets/images/polls.svg',
@@ -246,7 +228,7 @@ class _SideDrawerState extends State<SideDrawer> {
     );
   }
 
-  Widget buildGroupBudgetingItem() {
+  Widget buildGroupBudgetingItem(BuildContext context) {
     return ListTile(
       leading: SvgPicture.asset(
         'assets/images/group_budgeting.svg',
@@ -269,7 +251,7 @@ class _SideDrawerState extends State<SideDrawer> {
     );
   }
 
-  Widget buildSharedDocumentsItem() {
+  Widget buildSharedDocumentsItem(BuildContext context) {
     return ListTile(
       leading: SvgPicture.asset(
         'assets/images/shared_documents.svg',
@@ -285,7 +267,7 @@ class _SideDrawerState extends State<SideDrawer> {
     );
   }
 
-  Widget buildPinsItem() {
+  Widget buildPinsItem(BuildContext context) {
     return ListTile(
       leading: SvgPicture.asset(
         'assets/images/faq.svg',


### PR DESCRIPTION
### Changes:
Everytime we open the sidemenu, it triggers async fetch of client avatars and name. This has been changed to fetch only once the client is logged in. So it doesn't show re-rendering animations.