### PR TITLE
Avoid bug that avatar fetch is failed sometimes on v0.6

### DIFF
--- a/app/lib/widgets/CustomAvatar.dart
+++ b/app/lib/widgets/CustomAvatar.dart
@@ -32,16 +32,11 @@ class CustomAvatar extends StatefulWidget {
 class _CustomAvatarState extends State<CustomAvatar> {
   Future<Uint8List>? getAvatar() async {
     if (widget.avatar == null) {
+      // hasAvatar == false
       return Uint8List(0);
     }
-    // sometimes fetch of avatar failed because encryption not working well
-    // this is hack to avoid that issue
-    try {
-      FfiBufferUint8 avatar = await widget.avatar!;
-      return avatar.asTypedList();
-    } catch (e) {
-      return Uint8List(0);
-    }
+    FfiBufferUint8 avatar = await widget.avatar!;
+    return avatar.asTypedList(); // sometimes empty array may be returned
   }
 
   @override

--- a/native/effektio/src/api/profile.rs
+++ b/native/effektio/src/api/profile.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use log::info;
 use matrix_sdk::{
     media::{MediaFormat, MediaRequest},
@@ -65,7 +65,9 @@ impl UserProfile {
                 if let Ok(res) = client.media().get_media_content(&req, true).await {
                     return Ok(FfiBuffer::new(res));
                 }
-                bail!("Could not get media content from user profile");
+                // sometimes fetching failed, i don't know that reason
+                info!("Could not get media content from user profile");
+                Ok(FfiBuffer::new(vec![]))
             })
             .await?
     }
@@ -120,7 +122,9 @@ impl RoomProfile {
                 if let Ok(res) = client.media().get_media_content(&req, true).await {
                     return Ok(FfiBuffer::new(res));
                 }
-                bail!("Could not get media content from room profile");
+                // sometimes fetching failed, i don't know that reason
+                info!("Could not get media content from room profile");
+                Ok(FfiBuffer::new(vec![]))
             })
             .await?
     }

--- a/native/effektio/src/api/verification.rs
+++ b/native/effektio/src/api/verification.rs
@@ -628,16 +628,15 @@ impl VerificationController {
             |ev: OriginalSyncRoomMessageEvent,
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
-                if let MessageType::VerificationRequest(_) = &ev.content.msgtype {
-                    let dev_id = c
-                        .device_id()
-                        .expect("guest user cannot get device id")
-                        .to_string();
-                    info!("{} got {}", dev_id, ev.content.event_type());
+                if let MessageType::VerificationRequest(content) = &ev.content.msgtype {
+                    let dev_id = c.device_id().expect("guest user cannot get device id");
+                    let event_type = ev.content.event_type();
+                    info!("{} got {}", dev_id, event_type);
                     let event_id = ev.event_id;
+                    let methods = content.methods.clone();
                     let msg = VerificationEvent::new(
                         &c,
-                        ev.content.event_type().to_string(),
+                        event_type.to_string(),
                         Some(event_id.clone()),
                         None,
                         ev.sender.clone(),
@@ -659,11 +658,12 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let event_id = ev.clone().content.relates_to.event_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let event_id = ev.content.relates_to.event_id;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     Some(event_id.clone()),
                     None,
                     ev.sender.clone(),
@@ -684,11 +684,13 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let event_id = ev.clone().content.relates_to.event_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let event_id = ev.content.relates_to.event_id;
+                let method = ev.content.method;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     Some(event_id.clone()),
                     None,
                     ev.sender.clone(),
@@ -709,11 +711,12 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let event_id = ev.clone().content.relates_to.event_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let event_id = ev.content.relates_to.event_id;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     Some(event_id.clone()),
                     None,
                     ev.sender.clone(),
@@ -734,11 +737,13 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let event_id = ev.clone().content.relates_to.event_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let event_id = ev.content.relates_to.event_id;
+                let method = ev.content.method;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     Some(event_id.clone()),
                     None,
                     ev.sender.clone(),
@@ -759,11 +764,13 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let event_id = ev.clone().content.relates_to.event_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let event_id = ev.content.relates_to.event_id;
+                let key = ev.content.key;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     Some(event_id.clone()),
                     None,
                     ev.sender.clone(),
@@ -784,11 +791,14 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let event_id = ev.clone().content.relates_to.event_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let event_id = ev.content.relates_to.event_id;
+                let mac = ev.content.mac;
+                let keys = ev.content.keys;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     Some(event_id.clone()),
                     None,
                     ev.sender.clone(),
@@ -809,11 +819,12 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let event_id = ev.clone().content.relates_to.event_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let event_id = ev.content.relates_to.event_id;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     Some(event_id.clone()),
                     None,
                     ev.sender.clone(),
@@ -834,7 +845,8 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
             },
         );
         self.sync_room_encrypted_handle = Some(handle);
@@ -887,15 +899,14 @@ impl VerificationController {
             |ev: ToDeviceKeyVerificationRequestEvent,
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
-                let dev_id = c
-                    .device_id()
-                    .expect("guest user cannot get device id")
-                    .to_string();
-                info!("{} got {}", dev_id, ev.content.event_type());
-                let txn_id = ev.clone().content.transaction_id;
+                let dev_id = c.device_id().expect("guest user cannot get device id");
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let txn_id = ev.content.transaction_id;
+                let methods = ev.content.methods.clone();
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     None,
                     Some(txn_id.clone()),
                     ev.sender.clone(),
@@ -916,11 +927,13 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let txn_id = ev.clone().content.transaction_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let txn_id = ev.content.transaction_id;
+                let methods = ev.content.methods;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     None,
                     Some(txn_id.clone()),
                     ev.sender.clone(),
@@ -941,11 +954,13 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let txn_id = ev.clone().content.transaction_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let txn_id = ev.content.transaction_id;
+                let method = ev.content.method;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     None,
                     Some(txn_id.clone()),
                     ev.sender.clone(),
@@ -966,11 +981,12 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let txn_id = ev.clone().content.transaction_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let txn_id = ev.content.transaction_id;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     None,
                     Some(txn_id.clone()),
                     ev.sender.clone(),
@@ -991,11 +1007,13 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let txn_id = ev.clone().content.transaction_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let txn_id = ev.content.transaction_id;
+                let method = ev.content.method;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     None,
                     Some(txn_id.clone()),
                     ev.sender.clone(),
@@ -1016,11 +1034,13 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let txn_id = ev.clone().content.transaction_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let txn_id = ev.content.transaction_id;
+                let key = ev.content.key;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     None,
                     Some(txn_id.clone()),
                     ev.sender.clone(),
@@ -1041,11 +1061,14 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let txn_id = ev.clone().content.transaction_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let txn_id = ev.content.transaction_id;
+                let mac = ev.content.mac;
+                let keys = ev.content.keys;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     None,
                     Some(txn_id.clone()),
                     ev.sender.clone(),
@@ -1066,11 +1089,12 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
-                let txn_id = ev.clone().content.transaction_id;
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
+                let txn_id = ev.content.transaction_id;
                 let msg = VerificationEvent::new(
                     &c,
-                    ev.content.event_type().to_string(),
+                    event_type.to_string(),
                     None,
                     Some(txn_id.clone()),
                     ev.sender.clone(),
@@ -1091,7 +1115,8 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
             },
         );
         self.to_device_room_encrypted_handle = Some(handle);
@@ -1102,7 +1127,8 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
             },
         );
         self.to_device_room_key_handle = Some(handle);
@@ -1113,7 +1139,8 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
             },
         );
         self.to_device_room_key_request_handle = Some(handle);
@@ -1124,7 +1151,8 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
             },
         );
         self.to_device_forwarded_room_key_handle = Some(handle);
@@ -1135,7 +1163,8 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
             },
         );
         self.to_device_secret_send_handle = Some(handle);
@@ -1146,7 +1175,8 @@ impl VerificationController {
              c: MatrixClient,
              Ctx(mut me): Ctx<VerificationController>| async move {
                 let dev_id = c.device_id().expect("guest user cannot get device id");
-                info!("{} got {}", dev_id.to_string(), ev.content.event_type());
+                let event_type = ev.content.event_type();
+                info!("{} got {}", dev_id, event_type);
                 info!("ToDeviceSecretRequestEvent: {:?}", ev);
                 let secret_name = match &ev.content.action {
                     RequestAction::Request(s) => s,


### PR DESCRIPTION
Sometimes avatar fetching failed.
If failed, empty buffer will be returned.