### PR TITLE
[Chat] fix messages emoji container and tab size to get full viewport

### DIFF
--- a/app/lib/widgets/ChatBubbleBuilder.dart
+++ b/app/lib/widgets/ChatBubbleBuilder.dart
@@ -227,10 +227,11 @@ class _ChatBubbleBuilderState extends State<ChatBubbleBuilder>
     Map<String, dynamic> reactions = widget.message.metadata!['reactions'];
     List<String> keys = reactions.keys.toList();
     return Container(
-      width: keys.length * 35.5,
       margin: const EdgeInsets.all(2),
       decoration: BoxDecoration(
-        border: Border.all(color: AppCommonTheme.dividerColor, width: 0.2),
+        border: keys.isEmpty
+            ? null
+            : Border.all(color: AppCommonTheme.dividerColor, width: 0.2),
         borderRadius: BorderRadius.only(
           topLeft: widget.nextMessageInGroup
               ? const Radius.circular(12)

--- a/app/lib/widgets/ChatBubbleBuilder.dart
+++ b/app/lib/widgets/ChatBubbleBuilder.dart
@@ -89,7 +89,7 @@ class _ChatBubbleBuilderState extends State<ChatBubbleBuilder>
     setState(() {
       reactions.forEach((key, value) {
         count += value.count();
-        reactionTabs.add(Tab(text: '$key +${value.count()}'));
+        reactionTabs.add(Tab(text: '$key+${value.count()}'));
       });
       reactionTabs.insert(0, (Tab(text: 'All $count')));
       tabBarController =
@@ -108,6 +108,7 @@ class _ChatBubbleBuilderState extends State<ChatBubbleBuilder>
           children: [
             Flexible(
               child: TabBar(
+                isScrollable: true,
                 overlayColor:
                     MaterialStateProperty.all<Color>(Colors.transparent),
                 padding: const EdgeInsets.all(24),
@@ -122,8 +123,9 @@ class _ChatBubbleBuilderState extends State<ChatBubbleBuilder>
             const SizedBox(height: 10),
             Flexible(
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
+                padding: const EdgeInsets.symmetric(horizontal: 14),
                 child: TabBarView(
+                  viewportFraction: 1.0,
                   controller: tabBarController,
                   children: <Widget>[
                     buildReactionListing(keys),
@@ -225,7 +227,7 @@ class _ChatBubbleBuilderState extends State<ChatBubbleBuilder>
     Map<String, dynamic> reactions = widget.message.metadata!['reactions'];
     List<String> keys = reactions.keys.toList();
     return Container(
-      width: keys.length * 50,
+      width: keys.length * 35.5,
       margin: const EdgeInsets.all(2),
       decoration: BoxDecoration(
         border: Border.all(color: AppCommonTheme.dividerColor, width: 0.2),


### PR DESCRIPTION
- [x] fix emoji container width that appears to be long than emojis length.
- [x] make tab bar scrollable so to get full viewport of emojis regardless of count. 