### PR TITLE
Windows title for desktop including bugfix on osx

### DIFF
--- a/app/macos/Podfile
+++ b/app/macos/Podfile
@@ -27,6 +27,7 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_macos_podfile_setup
 
 target 'Runner' do
+  use_frameworks!
   use_modular_headers!
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))


### PR DESCRIPTION
This PR is the 2nd PR about window title for desktop.
Original PR worked on windows, but not on macos.
I found that bug in `Podfile` under comparing with example pod of `flutter-desktop-embedding`.